### PR TITLE
Read the port for the master and slave from the environment

### DIFF
--- a/cmd/master/main.go
+++ b/cmd/master/main.go
@@ -4,7 +4,7 @@ import "fmt"
 import "github.com/aaronang/cong-the-ripper/master"
 
 func main() {
-	fmt.Println("master starting...")
+	fmt.Println("Starting master...")
 	m := master.Init()
 	m.Run()
 }

--- a/cmd/slave/main.go
+++ b/cmd/slave/main.go
@@ -3,5 +3,5 @@ package main
 import "fmt"
 
 func main() {
-	fmt.Println("slave starting...")
+	fmt.Println("Starting slave...")
 }

--- a/lib/common.go
+++ b/lib/common.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"math/big"
+	"os"
 )
 
 // Global configuration
 const (
-	Port     = ":8080"
 	Protocol = "http://"
 
 	BodyType = "application/json"
@@ -28,6 +28,20 @@ const (
 
 	AWSRegion = "eu-west-1"
 )
+
+func MasterPort() string {
+	if os.Getenv("MASTERPORT") != "" {
+		return ":" + os.Getenv("MASTERPORT")
+	}
+	return ":8080"
+}
+
+func SlavePort() string {
+	if os.Getenv("SLAVEPORT") != "" {
+		return ":" + os.Getenv("SLAVEPORT")
+	}
+	return ":8080"
+}
 
 type Heartbeat struct {
 	SlaveId    string // aws.Instance.InstanceId

--- a/master/master.go
+++ b/master/master.go
@@ -3,6 +3,7 @@ package master
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/aaronang/cong-the-ripper/lib"
@@ -37,7 +38,8 @@ func (m *Master) Run() {
 	http.HandleFunc(lib.HeartbeatPath, m.heartbeatHandler)
 	http.HandleFunc(lib.StatusPath, m.statusHandler)
 
-	go http.ListenAndServe(lib.Port, nil)
+	go http.ListenAndServe(lib.MasterPort(), nil)
+	fmt.Println("Master running on port", lib.MasterPort())
 
 	for {
 		select {
@@ -111,7 +113,7 @@ func TerminateSlaves(svc *ec2.EC2, instances []*ec2.Instance) (*ec2.TerminateIns
 
 // SendTask sends a task to a slave instance.
 func SendTask(t *lib.Task, i *ec2.Instance) (*http.Response, error) {
-	url := lib.Protocol + *i.PublicIpAddress + lib.Port + lib.TasksCreatePath
+	url := lib.Protocol + *i.PublicIpAddress + lib.SlavePort() + lib.TasksCreatePath
 	body, err := t.ToJSON()
 	if err != nil {
 		panic(err)

--- a/slave/slave.go
+++ b/slave/slave.go
@@ -20,5 +20,5 @@ func taskHandler(w http.ResponseWriter, r *http.Request) {
 
 func Run() {
 	http.HandleFunc(lib.TasksCreatePath, taskHandler)
-	http.ListenAndServe(lib.Port, nil)
+	http.ListenAndServe(lib.SlavePort(), nil)
 }


### PR DESCRIPTION
The port of the master and slave can be overridden by the setting the environment variables `MASTERPORT` and `SLAVEPORT`. This allows us to run the master and a slave locally at the same time for testing purposes.
